### PR TITLE
`option` for parsing result & avoid exceptions in tests

### DIFF
--- a/lib/parser/common.ml
+++ b/lib/parser/common.ml
@@ -7,9 +7,11 @@ open Angstrom
 open Ast
 
 let pp printer parser str =
-  Stdlib.Format.printf "%a" printer
-  @@ Result.ok_or_failwith
-  @@ Angstrom.parse_string ~consume:Angstrom.Consume.All parser str
+  match Angstrom.parse_string ~consume:Angstrom.Consume.All parser str with
+  | Ok res ->
+      Stdlib.Format.printf "%a" printer res
+  | Error _ ->
+      Stdlib.print_endline "syntax error"
 
 let skip_whitespaces = skip_while Char.is_whitespace
 

--- a/lib/parser/parser.ml
+++ b/lib/parser/parser.ml
@@ -7,5 +7,6 @@ open! Base
 let parse str =
   Angstrom.parse_string ~consume:Angstrom.Consume.All Structure.parse_structure
     str
+  |> Result.ok
 
 let parse_exn str = Result.ok_or_failwith (parse str)

--- a/lib/parser/parser.ml
+++ b/lib/parser/parser.ml
@@ -8,5 +8,3 @@ let parse str =
   Angstrom.parse_string ~consume:Angstrom.Consume.All Structure.parse_structure
     str
   |> Result.ok
-
-let parse_exn str = Result.ok_or_failwith (parse str)

--- a/lib/parser/parser.mli
+++ b/lib/parser/parser.mli
@@ -4,7 +4,5 @@
 
 open! Base
 
-val parse_exn : string -> Ast.structure
-(** Raises [Failure] exception if parsing fails *)
 val parse : string -> Ast.structure option
 (** Tries to parse [string]. Returns [None] if parsing fails *)

--- a/lib/parser/parser.mli
+++ b/lib/parser/parser.mli
@@ -4,7 +4,7 @@
 
 open! Base
 
-val parse : string -> (Ast.structure, string) result
-
 val parse_exn : string -> Ast.structure
 (** Raises [Failure] exception if parsing fails *)
+val parse : string -> Ast.structure option
+(** Tries to parse [string]. Returns [None] if parsing fails *)

--- a/lib/parser/test.ml
+++ b/lib/parser/test.ml
@@ -6,7 +6,12 @@ open! Base
 open Ast
 
 (** Parse string and pretty print the output *)
-let pp str = Stdlib.Format.printf "%a" pp_structure (Parser.parse_exn str)
+let pp string =
+  match Parser.parse string with
+  | Some str ->
+      Stdlib.Format.printf "%a" pp_structure str
+  | None ->
+      Stdlib.print_endline "syntax error"
 
 let%expect_test "parse_custom_operator1" =
   pp "let (>>=) a b = a ** b" ;


### PR DESCRIPTION
- No point in using `result` for parsing result as error message is always the same - "end of input" (would be great to fix it later on).
It's quite cryptic and there's not much point in returning it to user
- Tests should not fall with exceptions in case of a parsing error